### PR TITLE
Add advanced trading bot with indicators and AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # ROBO
-Robot trading
+
+This repository contains a minimal example of an automated trading bot using a simple moving average strategy.
+
+## Usage
+
+1. Install dependencies for the simple bot:
+   ```bash
+   pip install requests pandas
+   ```
+2. Run the simple moving average bot:
+   ```bash
+   python trading_bot.py
+   ```
+
+### Advanced Bot
+
+An extended example using additional technical indicators and a simple
+machine learning model is provided in `advanced_trading_bot.py`.
+
+1. Install extra dependencies:
+   ```bash
+   pip install requests pandas ta scikit-learn
+   ```
+2. Run the advanced bot:
+   ```bash
+   python advanced_trading_bot.py
+   ```
+
+Both example bots fetch pricing data from a placeholder API. Replace
+`https://example.com/api` in the scripts with a real data provider when
+running against live markets.

--- a/advanced_trading_bot.py
+++ b/advanced_trading_bot.py
@@ -1,0 +1,73 @@
+import requests
+import pandas as pd
+import numpy as np
+import time
+import logging
+from sklearn.linear_model import LogisticRegression
+import ta
+
+class AdvancedTradingBot:
+    """Trading bot with multiple indicators and a simple ML model."""
+
+    def __init__(self, symbol, api_url="https://example.com/api", short_window=5, long_window=20, rsi_window=14):
+        self.symbol = symbol
+        self.api_url = api_url
+        self.short_window = short_window
+        self.long_window = long_window
+        self.rsi_window = rsi_window
+        self.history = []
+        self.model = LogisticRegression()
+        self.trained = False
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+    def fetch_price(self):
+        """Fetch the latest price from an API."""
+        response = requests.get(f"{self.api_url}?symbol={self.symbol}")
+        data = response.json()
+        return float(data["price"])
+
+    def compute_indicators(self, prices):
+        df = pd.DataFrame({"price": prices})
+        df["short_ma"] = df["price"].rolling(window=self.short_window).mean()
+        df["long_ma"] = df["price"].rolling(window=self.long_window).mean()
+        df["rsi"] = ta.momentum.rsi(df["price"], window=self.rsi_window)
+        df["macd"] = ta.trend.macd(df["price"])
+        df.fillna(method="bfill", inplace=True)
+        df.fillna(method="ffill", inplace=True)
+        return df
+
+    def train_model(self, df):
+        if len(df) <= self.long_window:
+            return
+        df["target"] = (df["price"].shift(-1) > df["price"]).astype(int)
+        X = df[["short_ma", "long_ma", "rsi", "macd"]][:-1]
+        y = df["target"][:-1]
+        if len(np.unique(y)) > 1:
+            self.model.fit(X, y)
+            self.trained = True
+
+    def predict_signal(self, row):
+        if not self.trained:
+            return "HOLD"
+        X = row[["short_ma", "long_ma", "rsi", "macd"]].values.reshape(1, -1)
+        pred = self.model.predict(X)[0]
+        return "BUY" if pred == 1 else "SELL"
+
+    def send_alert(self, message):
+        logging.info("ALERT: %s", message)
+
+    def run(self, iterations=10, delay=1):
+        for _ in range(iterations):
+            price = self.fetch_price()
+            self.history.append(price)
+            df = self.compute_indicators(self.history)
+            self.train_model(df)
+            signal = self.predict_signal(df.iloc[-1])
+            print(f"{self.symbol} price: {price} signal: {signal}")
+            if signal != "HOLD":
+                self.send_alert(signal)
+            time.sleep(delay)
+
+if __name__ == "__main__":
+    bot = AdvancedTradingBot("AAPL")
+    bot.run()

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,0 +1,41 @@
+import requests
+import pandas as pd
+import time
+
+class MovingAverageBot:
+    def __init__(self, symbol, short_window=5, long_window=20, api_url="https://example.com/api"):
+        self.symbol = symbol
+        self.short_window = short_window
+        self.long_window = long_window
+        self.api_url = api_url
+        self.history = []
+
+    def fetch_price(self):
+        # Placeholder for fetching current price from an API
+        # This function would typically perform an HTTP request to a broker or data provider
+        response = requests.get(f"{self.api_url}?symbol={self.symbol}")
+        data = response.json()
+        return float(data["price"])
+
+    def compute_signals(self):
+        series = pd.Series(self.history)
+        short_ma = series.rolling(window=self.short_window).mean()
+        long_ma = series.rolling(window=self.long_window).mean()
+        if len(series) >= self.long_window:
+            if short_ma.iloc[-1] > long_ma.iloc[-1]:
+                return "BUY"
+            elif short_ma.iloc[-1] < long_ma.iloc[-1]:
+                return "SELL"
+        return "HOLD"
+
+    def run(self, iterations=10, delay=1):
+        for _ in range(iterations):
+            price = self.fetch_price()
+            self.history.append(price)
+            signal = self.compute_signals()
+            print(f"{self.symbol} price: {price} signal: {signal}")
+            time.sleep(delay)
+
+if __name__ == "__main__":
+    bot = MovingAverageBot("AAPL")
+    bot.run()


### PR DESCRIPTION
## Summary
- provide `advanced_trading_bot.py` with extra indicators and a logistic regression model
- update README with instructions for running the new bot and installing its dependencies

## Testing
- `python -m py_compile trading_bot.py advanced_trading_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686ab1954c348324a4ea3da57795bee4