### PR TITLE
Add MetaTrader5 trading bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # ROBO
-Robot trading
+
+Simple trading bots built using the `MetaTrader5` Python package.
+
+## Installation
+
+The bots require the [MetaTrader 5](https://www.metatrader5.com/) terminal and
+its accompanying Python package. On Windows, install the package via pip:
+
+```bash
+pip install MetaTrader5
+```
+
+Download and install the MetaTrader 5 terminal, then enable automated trading
+via **Tools > Options > Expert Advisors > Allow automated trading**.
+
+## Configuration
+
+Ensure the terminal is logged in to your trading account. The bots connect
+using `mt5.initialize()` which by default searches for a running terminal.
+If necessary, pass the path to the terminal executable in `mt5.initialize()`.
+
+## Running the bots
+
+Two example bots are provided:
+
+- `trading_bot.py` – fetches the latest tick and places market orders based on
+  simple signals.
+- `advanced_trading_bot.py` – pulls recent historical data and makes decisions
+  using a basic strategy.
+
+Both bots will attempt to place orders when a signal is `BUY` or `SELL`.
+Failed connections or order submissions raise exceptions so you can add your
+own handling logic.

--- a/advanced_trading_bot.py
+++ b/advanced_trading_bot.py
@@ -1,0 +1,81 @@
+import time
+import random
+from statistics import mean
+
+try:
+    import MetaTrader5 as mt5
+except Exception as e:
+    mt5 = None
+    print(f"MetaTrader5 module not available: {e}")
+
+
+class AdvancedTradingBot:
+    """Advanced trading bot using historical data from MetaTrader5."""
+
+    def __init__(self, symbol="EURUSD", timeframe=mt5.TIMEFRAME_M1 if mt5 else None, volume=0.1):
+        self.symbol = symbol
+        self.timeframe = timeframe
+        self.volume = volume
+
+    def connect(self):
+        if mt5 is None:
+            raise RuntimeError("MetaTrader5 package is not installed.")
+        if not mt5.initialize():
+            raise ConnectionError(f"Failed to initialize MT5: {mt5.last_error()}")
+
+    def disconnect(self):
+        if mt5:
+            mt5.shutdown()
+
+    def fetch_price(self, bars=10):
+        """Fetch recent closing prices using copy_rates_from_pos."""
+        rates = mt5.copy_rates_from_pos(self.symbol, self.timeframe, 0, bars)
+        if rates is None or len(rates) == 0:
+            raise RuntimeError(f"Failed to fetch rates: {mt5.last_error()}")
+        return [r.close for r in rates]
+
+    def generate_signal(self, closes):
+        if len(closes) < 2:
+            return "HOLD"
+        if closes[-1] > mean(closes[:-1]):
+            return random.choice(["BUY", "HOLD"])
+        else:
+            return random.choice(["SELL", "HOLD"])
+
+    def place_order(self, signal):
+        tick = mt5.symbol_info_tick(self.symbol)
+        if tick is None:
+            raise RuntimeError(f"Failed to fetch tick: {mt5.last_error()}")
+        price = tick.ask if signal == "BUY" else tick.bid
+        order_type = mt5.ORDER_TYPE_BUY if signal == "BUY" else mt5.ORDER_TYPE_SELL
+        request = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "symbol": self.symbol,
+            "volume": self.volume,
+            "type": order_type,
+            "price": price,
+            "deviation": 20,
+            "magic": 234001,
+            "comment": "ROBO advanced order",
+            "type_time": mt5.ORDER_TIME_GTC,
+            "type_filling": mt5.ORDER_FILLING_FOK,
+        }
+        result = mt5.order_send(request)
+        if result is None or result.retcode != mt5.TRADE_RETCODE_DONE:
+            raise RuntimeError(f"Order failed: {result}")
+        print(f"Order placed: {result}")
+
+    def run(self, iterations=10, delay=60):
+        self.connect()
+        try:
+            for _ in range(iterations):
+                closes = self.fetch_price()
+                signal = self.generate_signal(closes)
+                if signal in ("BUY", "SELL"):
+                    try:
+                        self.place_order(signal)
+                    except Exception as e:
+                        print(f"Order error: {e}")
+                time.sleep(delay)
+        finally:
+            self.disconnect()

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,0 +1,79 @@
+import time
+import random
+
+try:
+    import MetaTrader5 as mt5
+except Exception as e:
+    mt5 = None
+    print(f"MetaTrader5 module not available: {e}")
+
+
+class TradingBot:
+    """Basic trading bot using MetaTrader5."""
+
+    def __init__(self, symbol="EURUSD", volume=0.1):
+        self.symbol = symbol
+        self.volume = volume
+
+    def connect(self):
+        """Initialize connection to MetaTrader 5 terminal."""
+        if mt5 is None:
+            raise RuntimeError("MetaTrader5 package is not installed.")
+        if not mt5.initialize():
+            raise ConnectionError(f"Failed to initialize MT5: {mt5.last_error()}")
+
+    def disconnect(self):
+        if mt5:
+            mt5.shutdown()
+
+    def fetch_price(self):
+        """Fetch the latest tick data for the configured symbol."""
+        tick = mt5.symbol_info_tick(self.symbol)
+        if tick is None:
+            raise RuntimeError(f"Failed to fetch tick: {mt5.last_error()}")
+        return tick.bid, tick.ask
+
+    def generate_signal(self, price):
+        """Dummy signal generator."""
+        return random.choice(["BUY", "SELL", "HOLD"])
+
+    def place_order(self, signal):
+        """Send a market order using mt5.order_send."""
+        tick = mt5.symbol_info_tick(self.symbol)
+        if tick is None:
+            raise RuntimeError(f"Failed to fetch tick: {mt5.last_error()}")
+        price = tick.ask if signal == "BUY" else tick.bid
+        order_type = mt5.ORDER_TYPE_BUY if signal == "BUY" else mt5.ORDER_TYPE_SELL
+        request = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "symbol": self.symbol,
+            "volume": self.volume,
+            "type": order_type,
+            "price": price,
+            "deviation": 20,
+            "magic": 234000,
+            "comment": "ROBO order",
+            "type_time": mt5.ORDER_TIME_GTC,
+            "type_filling": mt5.ORDER_FILLING_FOK,
+        }
+        result = mt5.order_send(request)
+        if result is None or result.retcode != mt5.TRADE_RETCODE_DONE:
+            raise RuntimeError(f"Order failed: {result}")
+        print(f"Order placed: {result}")
+
+    def run(self, iterations=10, delay=1):
+        """Run the trading loop."""
+        self.connect()
+        try:
+            for _ in range(iterations):
+                bid, ask = self.fetch_price()
+                price = (bid + ask) / 2
+                signal = self.generate_signal(price)
+                if signal in ("BUY", "SELL"):
+                    try:
+                        self.place_order(signal)
+                    except Exception as e:
+                        print(f"Order error: {e}")
+                time.sleep(delay)
+        finally:
+            self.disconnect()


### PR DESCRIPTION
## Summary
- add basic `trading_bot.py` and `advanced_trading_bot.py` that integrate with MetaTrader5
- update README with installation notes and usage information

## Testing
- `pip install MetaTrader5` *(fails: no matching distribution)*
- `python -m py_compile trading_bot.py advanced_trading_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686abebc95d48324a3d04bf43114e2cb