### PR TITLE
Add COT analyzer HTML page and dependencies

### DIFF
--- a/cot_analyzer.html
+++ b/cot_analyzer.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>XAU/USD — COT Disaggregated (Gold 088691) – Rapport & Plan</title>
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<style>
+  :root{
+    --bg:#0f1115; --panel:#151923; --ink:#eef1f7; --muted:#9aa3b2;
+    --accent:#59c3ff; --ok:#23c55e; --warn:#f59e0b; --bad:#ef4444;
+    --card:#0f172a; --soft:#0b1220; --line:#212637;
+  }
+  html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial}
+  .wrap{max-width:1100px;margin:auto;padding:24px}
+  h1{font-size:24px;margin:0 0 12px}
+  h2{font-size:18px;margin:0 0 8px}
+  .row{display:grid;gap:14px}
+  .g2{grid-template-columns:1fr 1fr}
+  .g3{grid-template-columns:1fr 1fr 1fr}
+  .card{background:linear-gradient(180deg,var(--panel),var(--soft));border:1px solid var(--line);border-radius:14px;box-shadow:0 10px 25px rgba(0,0,0,.25)}
+  .card .hd{padding:14px 16px;border-bottom:1px solid var(--line)}
+  .card .bd{padding:14px 16px}
+  label{display:block;color:var(--muted);margin:0 0 6px}
+  textarea,input{width:100%;box-sizing:border-box;background:#0b1220;border:1px solid #1c2435;color:var(--ink);padding:10px;border-radius:10px;outline:none}
+  textarea:focus,input:focus{border-color:#304063}
+  textarea{min-height:160px;resize:vertical}
+  .btns{display:flex;flex-wrap:wrap;gap:8px}
+  button{background:#1e293b;color:#e9eef9;border:1px solid #2b3b57;padding:9px 12px;border-radius:10px;cursor:pointer}
+  button:hover{filter:brightness(1.1)}
+  .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--line);border-radius:999px;background:#0e1526}
+  .ok{color:#b7f7c7;border-color:#1e3a2f;background:#0a1a12}
+  .bad{color:#ffc2c2;border-color:#40222a;background:#1a0d10}
+  .warn{color:#ffe8b5;border-color:#463719;background:#1a1308}
+  table{width:100%;border-collapse:collapse}
+  th,td{padding:8px;border-bottom:1px solid #1e2534;text-align:right}
+  th:first-child,td:first-child{text-align:left}
+  thead th{position:sticky;top:0;background:#0c1322;z-index:1}
+  .kpis{display:flex;flex-wrap:wrap;gap:8px}
+  .muted{color:var(--muted)}
+  .gridRS{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .box{border:1px dashed #2a3652;border-radius:12px;padding:10px}
+  .print-chunk{page-break-inside:avoid}
+  .hint{font-size:12px;color:#aab2c2}
+  @media print{
+    body{background:#fff;color:#000}
+    .card{background:#fff;border-color:#ddd;box-shadow:none}
+    .no-print{display:none!important}
+    .wrap{max-width:none;padding:0}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>🧠 XAU/USD — Lecteur & Analyseur COT (Disaggregated, Gold 088691)</h1>
+  <div class="btns no-print" style="margin-bottom:10px">
+    <button id="btnAnalyse">Analyser</button>
+    <button id="btnExportPDF">Exporter PDF</button>
+    <button id="btnSave">Sauvegarder état</button>
+    <button id="btnLoad">Restaurer état</button>
+  </div>
+
+  <div class="row g2">
+    <div class="card print-chunk">
+      <div class="hd"><h2>Entrée — Rapport COT (Semaine en cours)</h2></div>
+      <div class="bd">
+        <label>Colle le bloc texte CFTC (Disaggregated – GOLD COMEX 088691). La ligne « All : … » sera détectée automatiquement.</label>
+        <textarea id="curTxt" placeholder="Colle ici…"></textarea>
+        <div class="row g2" style="margin-top:10px">
+          <div>
+            <label>Spot XAU/USD (optionnel)</label>
+            <input id="spot" type="number" step="0.1" placeholder="ex: 2400.5" />
+          </div>
+          <div>
+            <label>Historique MM Net (CSV facultatif : date,mm_net)</label>
+            <textarea id="histCsv" placeholder="2023-09-01, 120000&#10;2023-09-08, 125500"></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card print-chunk">
+      <div class="hd"><h2>Entrée — Rapport COT (Semaine précédente, S-1)</h2></div>
+      <div class="bd">
+        <label>Colle la semaine précédente pour calculer Δ semaine/semaine (facultatif mais recommandé).</label>
+        <textarea id="prevTxt" placeholder="Colle ici…"></textarea>
+        <p class="hint">Astuce : tu peux coller les blocs complets CFTC. Le parseur repère automatiquement la ligne « All : … ».</p>
+      </div>
+    </div>
+  </div>
+
+  <div id="report" class="print-chunk">
+    <div class="card">
+      <div class="hd"><h2>Résumé exécutif & KPIs</h2></div>
+      <div class="bd">
+        <div id="resume" style="margin-bottom:10px" class="muted">Colle tes rapports puis clique « Analyser ».</div>
+        <div class="kpis" id="kpis"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g2 print-chunk" style="margin-top:14px">
+    <div class="card">
+      <div class="hd"><h2>Lecture COT — Tableau</h2></div>
+      <div class="bd">
+        <div class="hint" style="margin-bottom:8px">Colonnes : Long / Short / Net et Δ (S−S-1). Catégories : Managed Money, Swap Dealers, Producer/Merchant, Other Reportables, Non-reportables + Open Interest.</div>
+        <div style="overflow:auto"><table id="tableCot"></table></div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="hd"><h2>Niveaux & Scénarios (H4/D1)</h2></div>
+      <div class="bd">
+        <div id="rsBox" class="gridRS" style="margin-bottom:10px"></div>
+        <div class="box">
+          <b>Scénarios</b>
+          <ul>
+            <li><b>Haussier</b> — Δ MM Net & OI positifs ; break & hold au-dessus R1 → viser R2/R3. Invalidation : perte de S1 + MM Net ↓.</li>
+            <li><b>Range</b> — MM Net stable (±5–10k) ; travailler S1↔R1 ; éviter milieu sans signal clair.</li>
+            <li><b>Cassure baissière</b> — Δ MM Net & OI négatifs ; cassure S1/S2 avec BOS H4 → shorts tactiques au pullback.</li>
+          </ul>
+          <div class="hint">Exécution : fenêtres Europe 08:00–11:00 & 13:00–16:00, triggers OB/FVG/SMT, RR ≥ 1:2.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g2 print-chunk" style="margin-top:14px">
+    <div class="card">
+      <div class="hd"><h2>Graphique — Managed Money (Long/Short/Net)</h2></div>
+      <div class="bd"><canvas id="chartBars" height="260"></canvas></div>
+    </div>
+    <div class="card">
+      <div class="hd"><h2>Graphique — MM Net S-1 vs S (explication S/S-1)</h2></div>
+      <div class="bd">
+        <div class="hint" style="margin-bottom:8px"><b>S</b> = semaine actuelle (dernier rapport) • <b>S-1</b> = semaine précédente. Δ = S − S-1.</div>
+        <canvas id="chartDelta" height="260"></canvas>
+      </div>
+    </div>
+  </div>
+
+  <div class="card print-chunk" style="margin-top:14px">
+    <div class="hd"><h2>Agenda macro — remplissage rapide & export ICS</h2></div>
+    <div class="bd">
+      <div class="btns no-print" style="margin-bottom:8px">
+        <button id="btnFillAgenda">Remplir auto (règles)</button>
+        <button id="btnExportICS">Exporter .ics</button>
+      </div>
+      <div class="row g3">
+        <div><label>NFP (US)</label><input id="nfpDate" type="date"></div>
+        <div><label>CPI (US)</label><input id="cpiDate" type="date"></div>
+        <div><label>PCE core (US)</label><input id="pceDate" type="date"></div>
+        <div><label>FOMC – début</label><input id="fomcStart" type="date"></div>
+        <div><label>FOMC – fin</label><input id="fomcEnd" type="date"></div>
+        <div><label>Notes</label><input id="macroNotes" placeholder="Ex. : CPI>attendu ⇒ USD↑ Or↓" /></div>
+      </div>
+      <p class="hint" style="margin-top:8px">Rappel : le COT est daté du mardi et publié le vendredi → filtre de biais hebdomadaire, <i>pas</i> un outil intraday.</p>
+    </div>
+  </div>
+</div>
+
+<script>
+(()=> {
+  const $ = (s) => document.querySelector(s);
+  const $$ = (s) => Array.from(document.querySelectorAll(s));
+  const stateKeys = ["curTxt","prevTxt","spot","histCsv","nfpDate","cpiDate","pceDate","fomcStart","fomcEnd","macroNotes"];
+
+  function fmt(n){ return (n==null||!isFinite(n))? "—" : n.toLocaleString('fr-FR'); }
+  function pct(n,d){ if(!d) return 0; return 100*(n/d); }
+  function parseHistoryCSV(csv){
+    if(!csv) return [];
+    return csv.split(/\r?\n/).map(l=>{
+      const [date,netRaw] = l.split(/,|;|\t/);
+      const net = parseFloat((netRaw||"").replace(/\s/g,""));
+      if(isFinite(net)) return {date:(date||"").trim(), net};
+      return null;
+    }).filter(Boolean);
+  }
+  function cotIndex(mmNet, arr, win=156){
+    if(mmNet==null || !arr?.length) return null;
+    const nets = arr.map(r=>r.net).filter(v=>typeof v==="number");
+    const slice = nets.slice(-win);
+    if(!slice.length) return null;
+    const mn = Math.min(...slice), mx = Math.max(...slice);
+    if(mx===mn) return 50;
+    return 100*(mmNet-mn)/(mx-mn);
+  }
+
+  function parseCotDisaggregated(raw){
+    if(!raw) return null;
+    const lineIdx = raw.indexOf("Positions");
+    const part = lineIdx>=0 ? raw.slice(lineIdx) : raw;
+    const m = part.match(/^\s*All\s*:.*$/im);
+    const allLine = m ? m[0] : null;
+    if(!allLine) return null;
+    const nums = (allLine.match(/-?\d[\d,]*/g)||[]).map(s=>parseInt(s.replace(/,/g,""),10));
+    if(nums.length < 14) return null;
+    const [openInterest, pmL,pmS, swL,swS,swSp, mmL,mmS,mmSp, oL,oS,oSp, nrL,nrS] = nums.slice(0,14);
+    return {
+      openInterest,
+      producer:{long:pmL, short:pmS},
+      swaps:{long:swL, short:swS, spread:swSp},
+      mm:{long:mmL, short:mmS, spread:mmSp},
+      other:{long:oL, short:oS, spread:oSp},
+      nonrep:{long:nrL, short:nrS},
+    };
+  }
+  function deltas(cur, prev){
+    if(!cur||!prev) return null;
+    const d=(a,b)=> (a??0)-(b??0);
+    return {
+      openInterest: d(cur.openInterest, prev.openInterest),
+      producer:{ long:d(cur.producer.long,prev.producer.long), short:d(cur.producer.short,prev.producer.short) },
+      swaps:{ long:d(cur.swaps.long,prev.swaps.long), short:d(cur.swaps.short,prev.swaps.short) },
+      mm:{ long:d(cur.mm.long,prev.mm.long), short:d(cur.mm.short,prev.mm.short) },
+      other:{ long:d(cur.other.long,prev.other.long), short:d(cur.other.short,prev.other.short) },
+      nonrep:{ long:d(cur.nonrep.long,prev.nonrep.long), short:d(cur.nonrep.short,prev.nonrep.short) },
+    };
+  }
+  function levels(spot){
+    const p = Number(spot);
+    if(!isFinite(p) || p<=0) return null;
+    const up=[.006,.015,.03], dn=[.006,.015,.03];
+    return {
+      R: up.map(x=>+(p*(1+x)).toFixed(1)),
+      S: dn.map(x=>+(p*(1-x)).toFixed(1))
+    };
+  }
+  function inferBias(cur, prev){
+    if(!cur||!prev) return null;
+    const dNet = (cur.mm.long-cur.mm.short) - (prev.mm.long-prev.mm.short);
+    const dOI = cur.openInterest - prev.openInterest;
+    if(dNet>10000 && dOI>0) return { bias:"Haussier renforcé", reason:`MM Net +${fmt(dNet)} et OI +${fmt(dOI)}` };
+    if(dNet<-10000) return { bias:"Prudence / défensif", reason:`MM Net ${fmt(dNet)}` };
+    return { bias:"Neutre-haussier", reason:`Flux MM modéré (${fmt(dNet)}), OI ${dOI>0?"+":""}${fmt(dOI)}` };
+  }
+
+  let chartBars=null, chartDelta=null;
+  function renderCharts(cur, prev){
+    const ctx1 = $("#chartBars").getContext("2d");
+    const ctx2 = $("#chartDelta").getContext("2d");
+    if(chartBars){ chartBars.destroy(); chartBars=null; }
+    if(chartDelta){ chartDelta.destroy(); chartDelta=null; }
+
+    const mmL = cur.mm.long, mmS = cur.mm.short, mmN = mmL - mmS;
+    chartBars = new Chart(ctx1, {
+      type:"bar",
+      data:{
+        labels:["Long","Short","Net"],
+        datasets:[{label:"Contrats", data:[mmL,mmS,mmN]}]
+      },
+      options:{ responsive:true, plugins:{legend:{display:true}}, scales:{ y:{ beginAtZero:true } } }
+    });
+
+    const prevN = prev? (prev.mm.long-prev.mm.short) : 0;
+    chartDelta = new Chart(ctx2, {
+      type:"bar",
+      data:{ labels:["S-1","S"], datasets:[{ label:"Net", data:[prevN,mmN] }] },
+      options:{ responsive:true, plugins:{legend:{display:true}}, scales:{ y:{ beginAtZero:true } } }
+    });
+  }
+
+  function renderTable(cur, prev, d){
+    const el = $("#tableCot");
+    if(!cur){ el.innerHTML = "<tbody><tr><td>Aucune donnée.</td></tr></tbody>"; return; }
+    const row = (label, L,S, dL,dS) => {
+      const N = L - S;
+      const dN = (dL!=null && dS!=null)? (dL-dS): null;
+      return `<tr>
+        <td>${label}</td>
+        <td>${fmt(L)}</td>
+        <td>${fmt(S)}</td>
+        <td>${fmt(N)}</td>
+        <td>${dL==null?"—":fmt(dL)}</td>
+        <td>${dS==null?"—":fmt(dS)}</td>
+        <td>${dN==null?"—":fmt(dN)}</td>
+      </tr>`;
+    };
+    const body = [
+      row("Managed Money", cur.mm.long, cur.mm.short, d?.mm.long, d?.mm.short),
+      row("Swap Dealers", cur.swaps.long, cur.swaps.short, d?.swaps.long, d?.swaps.short),
+      row("Producer/Merchant", cur.producer.long, cur.producer.short, d?.producer.long, d?.producer.short),
+      row("Other Reportables", cur.other.long, cur.other.short, d?.other.long, d?.other.short),
+      row("Non-reportables", cur.nonrep.long, cur.nonrep.short, d?.nonrep.long, d?.nonrep.short),
+      `<tr style="background:#0c1322"><td><b>Open Interest</b></td><td>${fmt(cur.openInterest)}</td><td>—</td><td>—</td><td>${fmt(d?.openInterest)}</td><td>—</td><td>—</td></tr>`
+    ].join("");
+    el.innerHTML = `<thead>
+      <tr><th>Catégorie</th><th>Long</th><th>Short</th><th>Net</th><th>Δ Long</th><th>Δ Short</th><th>Δ Net</th></tr>
+      </thead><tbody>${body}</tbody>`;
+  }
+
+  function renderKpis(cur, prev, histArr, spotVal){
+    const box = $("#kpis"); box.innerHTML = "";
+    if(!cur){ return; }
+    const mmNet = cur.mm.long - cur.mm.short;
+    const mmPct = pct(mmNet, cur.openInterest);
+    const mmIdx = cotIndex(mmNet, histArr, 156);
+    const dOI = prev? (cur.openInterest - prev.openInterest) : null;
+    const add = (txt, cls="pill")=>{
+      const s = document.createElement("span"); s.className=cls; s.textContent=txt; box.appendChild(s);
+    };
+    add(`MM Net : ${fmt(mmNet)}`);
+    add(`Net %OI : ${isFinite(mmPct)? mmPct.toFixed(2)+"%":"—"}`);
+    if(mmIdx!=null) add(`COT Index(156) : ${mmIdx.toFixed(0)}`);
+    add(`Open Interest : ${fmt(cur.openInterest)}`);
+    if(dOI!=null) add(`Δ OI : ${dOI>0?"+":""}${fmt(dOI)}`, dOI>0?"pill ok":(dOI<0?"pill bad":"pill"));
+    if(spotVal){
+      const lvl = levels(spotVal);
+      if(lvl){
+        add(`R1 ${lvl.R[0]} • R2 ${lvl.R[1]} • R3 ${lvl.R[2]}`, "pill warn");
+        add(`S1 ${lvl.S[0]} • S2 ${lvl.S[1]} • S3 ${lvl.S[2]}`, "pill warn");
+      }
+    }
+  }
+
+  function renderRS(spotVal){
+    const box = $("#rsBox"); box.innerHTML = "";
+    const lvl = levels(spotVal);
+    if(!lvl){ box.innerHTML = `<div class="muted">Renseigne le spot pour générer R/S.</div>`; return; }
+    const mk = (title, arr)=> `<div class="box"><b>${title}</b><ul style="margin:6px 0 0 18px">${arr.map((v,i)=>`<li>${title[0]}${i+1}: <b>${v}</b></li>`).join("")}</ul></div>`;
+    box.innerHTML = mk("Résistances",lvl.R)+mk("Supports",lvl.S);
+  }
+
+  function fillAgendaHeuristics(){
+    const now=new Date(); const y=now.getFullYear(), m=now.getMonth();
+    const fmt=d=>d? d.toISOString().slice(0,10):"";
+    const biz=(n)=>{const d=new Date(Date.UTC(y,m,1)); let c=0; while(d.getUTCMonth()===m){const wd=d.getUTCDay(); if(wd>=1&&wd<=5){c++; if(c===n) return new Date(d);} d.setUTCDate(d.getUTCDate()+1);} return null;};
+    const nth=(wd,n)=>{const d=new Date(Date.UTC(y,m,1)); let c=0; while(d.getUTCMonth()===m){ if(d.getUTCDay()===wd){c++; if(c===n) return new Date(d);} d.setUTCDate(d.getUTCDate()+1);} return null;};
+    const eomWeekday=(wd)=>{const d=new Date(Date.UTC(y,m+1,0)); while(d.getUTCDay()!==wd){ d.setUTCDate(d.getUTCDate()-1);} return d;};
+    $("#nfpDate").value = fmt(biz(5));          // 1er vendredi ouvré ~ NFP
+    $("#cpiDate").value = fmt(nth(3,2));        // CPI ~ 2e mercredi (3=Wed)
+    $("#pceDate").value = fmt(eomWeekday(5));   // PCE core ~ dernier vendredi (5=Fri)
+    $("#fomcStart").value = "";                 // dates à ajuster
+    $("#fomcEnd").value = "";
+  }
+
+  async function exportPDF(){
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF({orientation:"portrait",unit:"pt",format:"a4"});
+    const pageW=pdf.internal.pageSize.getWidth(), pageH=pdf.internal.pageSize.getHeight();
+    const margin=28, maxW=pageW-2*margin, maxH=pageH-2*margin;
+    const chunks = $$(".print-chunk");
+    let page=0;
+    for(const el of chunks){
+      const canvas = await html2canvas(el, {scale:2, backgroundColor:"#ffffff"});
+      const img = canvas.toDataURL("image/png");
+      const r = Math.min(maxW/canvas.width, maxH/canvas.height);
+      const w=canvas.width*r, h=canvas.height*r;
+      if(page>0) pdf.addPage();
+      pdf.addImage(img,"PNG",margin,margin,w,h);
+      pdf.setFontSize(9); pdf.setTextColor(120);
+      pdf.text("XAU/USD – Brief COT (auto)", margin, pageH-12);
+      pdf.text(String(page+1), pageW-margin, pageH-12, {align:"right"});
+      page++;
+    }
+    const name = `XAUUSD_COT_Brief_${new Date().toISOString().slice(0,10)}.pdf`;
+    pdf.save(name);
+  }
+
+  function analyse(){
+    const cur = parseCotDisaggregated($("#curTxt").value);
+    const prev = parseCotDisaggregated($("#prevTxt").value);
+    if(!cur){ alert("Impossible de lire la ligne « All : … » dans le rapport actuel."); return; }
+    const d = deltas(cur, prev);
+    const mmNet = cur.mm.long - cur.mm.short;
+    const mmPct = pct(mmNet, cur.openInterest);
+    const histArr = parseHistoryCSV($("#histCsv").value);
+    const mmIdx = cotIndex(mmNet, histArr, 156);
+    const bias = prev? inferBias(cur, prev) : null;
+
+    $("#resume").innerHTML = `
+      <b>Résumé</b> — ${bias? `<b>${bias.bias}</b> • ${bias.reason}.` : `en attente de S-1 pour Δ net.`}
+      ${isFinite(mmPct)? ` Net %OI (MM) ≈ <b>${mmPct.toFixed(2)}%</b>.`:""}
+      ${mmIdx!=null? ` COT Index(156) ≈ <b>${mmIdx.toFixed(0)}</b>.`:""}
+      <div class="hint">Le COT reflète le mardi et paraît le vendredi → filtre hebdomadaire, pas de timing intraday.</div>
+    `;
+    renderKpis(cur, prev, histArr, $("#spot").value);
+    renderTable(cur, prev, d);
+    renderRS($("#spot").value);
+    renderCharts(cur, prev);
+  }
+
+  function saveState(){
+    const o={}; stateKeys.forEach(k=> o[k] = $("#"+k)?.value ?? "");
+    localStorage.setItem("xau_cot_state", JSON.stringify(o));
+    alert("État sauvegardé localement.");
+  }
+  function loadState(){
+    try{
+      const o = JSON.parse(localStorage.getItem("xau_cot_state")||"{}");
+      stateKeys.forEach(k=> { if($("#"+k) && o[k]!=null) $("#"+k).value = o[k]; });
+      if(o.curTxt) analyse();
+    }catch(e){}
+  }
+
+  // Agenda export ICS
+  function exportICS(){
+    const items = [
+      ["NFP US", $("#nfpDate").value],
+      ["CPI US", $("#cpiDate").value],
+      ["PCE core", $("#pceDate").value],
+      ["FOMC Start", $("#fomcStart").value],
+      ["FOMC End", $("#fomcEnd").value]
+    ].filter(x=>x[1] && x[1].length===10);
+    if(!items.length) { alert("Aucune date valide pour ICS."); return; }
+    let ics = "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//XAU COT//EN\n";
+    items.forEach(([t,d])=>{
+      ics += `BEGIN:VEVENT\nDTSTART:${d.replace(/-/g,"")}\nSUMMARY:${t}\nEND:VEVENT\n`;
+    });
+    ics += "END:VCALENDAR";
+    const blob = new Blob([ics],{type:"text/calendar"});
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "agenda_macro.ics";
+    a.click();
+    setTimeout(()=>URL.revokeObjectURL(a.href), 3000);
+  }
+
+  // Bind
+  $("#btnAnalyse").addEventListener("click", analyse);
+  $("#btnExportPDF").addEventListener("click", exportPDF);
+  $("#btnSave").addEventListener("click", saveState);
+  $("#btnLoad").addEventListener("click", loadState);
+  $("#btnFillAgenda").addEventListener("click", fillAgendaHeuristics);
+  $("#btnExportICS").addEventListener("click", exportICS);
+
+  // Auto-load persisted state
+  loadState();
+})();
+</script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,667 @@
+{
+  "name": "ROBO",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "html2canvas": "^1.4.1",
+        "jspdf": "^3.0.2",
+        "lucide-react": "^0.542.0",
+        "recharts": "^3.1.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.2.tgz",
+      "integrity": "sha512-G0fQDJ5fAm6UW78HG6lNXyq09l0PrA1rpNY5i+ly17Zb1fMMFSmS+3lw4cnrAPGyouv2Y0ylujbY2Ieq3DSlKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.2.tgz",
+      "integrity": "sha512-vhNbYwaxNbk/IATK0Ki29k3qvTkGqwvCgyQAQ9MavvvBwjvKnMTswdbklJpcOAoMPN/qxF3Lyqob0zO+ZXkZ4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "html2canvas": "^1.4.1",
+    "jspdf": "^3.0.2",
+    "lucide-react": "^0.542.0",
+    "recharts": "^3.1.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add lucide-react, jspdf, html2canvas, and recharts dependencies
- introduce interactive `cot_analyzer.html` for COT report parsing, charting, and PDF export

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68bcd216d9788324854a011d64b8303b